### PR TITLE
Attempting to fix Github pages redirection issue

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -4,8 +4,10 @@ import { useStore } from 'vuex';
 
 import routes from "./routes";
 
+const baseUrl = import.meta.env.VITE_BASE_URL;
+
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(`${baseUrl}/`),
   routes,
 });
 


### PR DESCRIPTION
HTML5 history mode for the router encounters a problem when trying to set manually the URL in the address bar and riderects automatically to 404 page from github. This should fix the issue.